### PR TITLE
Jsondump

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -773,7 +773,7 @@ func (t Type) json(w io.Writer) {
 	case TYPE_ENUM, TYPE_STRUCT:
 		// since we handle groups at the field level, only named struct types make it in here
 		// so we can just call the named structs json dumper
-		fprintf(w, "s.WriteJSON(b);")
+		fprintf(w, "err = s.WriteJSON(b);")
 		writeErrCheck(w)
 	case TYPE_LIST:
 		fprintf(w, "{ err = b.WriteByte('[');")

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -682,24 +682,18 @@ func (n *node) defineTypeJsonFuncs(w io.Writer) {
 	g_imported["bufio"] = true
 	g_imported["bytes"] = true
 
-	buf := bytes.Buffer{}
-
-	switch n.Which() {
-	case NODE_ENUM:
-		n.jsonEnum(&buf)
-	case NODE_STRUCT:
-		n.jsonStruct(&buf)
-	}
-
 	fprintf(w, "func (s %s) WriteJSON(w io.Writer) error {\n", n.name)
 	fprintf(w, "b := bufio.NewWriter(w);")
 	fprintf(w, "var err error;")
-	if jsUsed {
-		fprintf(w, "js := json.NewEncoder(b);")
-		g_imported["encoding/json"] = true
-		jsUsed = false
+	fprintf(w, "var buf []byte;")
+	fprintf(w, "_ = buf;")
+
+	switch n.Which() {
+	case NODE_ENUM:
+		n.jsonEnum(w)
+	case NODE_STRUCT:
+		n.jsonStruct(w)
 	}
-	io.Copy(w, &buf)
 
 	fprintf(w, "err = b.Flush(); return err\n};\n")
 
@@ -712,12 +706,12 @@ func writeErrCheck(w io.Writer) {
 }
 
 func (n *node) jsonEnum(w io.Writer) {
-	jsUsed = true
-	fprintf(w, `err = js.Encode(s.String());`)
+	g_imported["encoding/json"] = true
+	fprintf(w, `buf, err = json.Marshal(s.String());`)
+	writeErrCheck(w)
+	fprintf(w, "_, err = b.Write(buf);")
 	writeErrCheck(w)
 }
-
-var jsUsed bool
 
 // Write statements that will write a json struct
 func (n *node) jsonStruct(w io.Writer) {
@@ -767,8 +761,10 @@ func (t Type) json(w io.Writer) {
 	case TYPE_UINT8, TYPE_UINT16, TYPE_UINT32, TYPE_UINT64,
 		TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_INT64,
 		TYPE_FLOAT32, TYPE_FLOAT64, TYPE_BOOL, TYPE_TEXT, TYPE_DATA:
-		jsUsed = true
-		fprintf(w, "err = js.Encode(s);")
+		g_imported["encoding/json"] = true
+		fprintf(w, "buf, err = json.Marshal(s);")
+		writeErrCheck(w)
+		fprintf(w, "_, err = b.Write(buf);")
 		writeErrCheck(w)
 	case TYPE_ENUM, TYPE_STRUCT:
 		// since we handle groups at the field level, only named struct types make it in here

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -669,6 +669,79 @@ func (n *node) defineStructFuncs(w io.Writer) {
 	}
 }
 
+// This writes the WriteJSON function.
+//
+// This is an unusual interface, but it was chosen because the types in go-capnproto
+// didn't match right to use the json.Marshaler interface.
+// This function recurses through the type, writing statements that will dump json to a wire
+// For all statements, the json encoder js and the bufio writer b will be in scope.
+// The value will be in scope as s. Some features need to redefine s, like unions.
+// In that case, Make a new block and redeclare s
+func (n *node) defineTypeJsonFunc(w io.Writer) {
+	fprintf(w, "func (s %s) WriteJSON(w io.Writer) error {\n", n.name)
+	fprintf(w, `
+		b := bufio.NewWriter(w)
+		js := json.NewEncoder(b);`)
+	switch n.Which() {
+	case NODE_ENUM:
+		n.jsonEnum(w)
+	case NODE_STRUCT:
+		n.jsonStruct(w)
+	}
+
+	fprintf(w, "b.Flush(); return nil\n}\n")
+}
+
+func (n *node) jsonEnum(w io.Writer) {
+	fprintf(w, `js.Encode(s.String());`)
+}
+
+// Write statements that will write a json struct
+func (n *node) jsonStruct(w io.Writer) {
+	fprintf(w, `b.WriteByte('{');`)
+	for i, f := range n.codeOrderFields() {
+		if f.DiscriminantValue() != 0xFFFF {
+			enumname := fmt.Sprintf("%s_%s", strings.ToUpper(n.name), strings.ToUpper(f.Name()))
+			fprintf(w, "if s.Which() == %s {", enumname)
+		}
+		if i != 0 {
+			fprintf(w, `
+				b.WriteByte(',');
+			`)
+		}
+		fprintf(w, `b.WriteString("\"%s\":");`, f.Name())
+		f.json(w)
+		if f.DiscriminantValue() != 0xFFFF {
+			fprintf(w, "};")
+		}
+	}
+	fprintf(w, `b.WriteByte('}');`)
+}
+
+// This function writes statements that write the fields json representation to the bufio.
+func (f *Field) json(w io.Writer) {
+	switch f.Which() {
+	case FIELD_SLOT:
+		fs := f.Slot()
+		switch fs.Type().Which() {
+		case TYPE_UINT8, TYPE_UINT16, TYPE_UINT32, TYPE_UINT64,
+			TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_INT64,
+			TYPE_FLOAT32, TYPE_FLOAT64, TYPE_BOOL, TYPE_TEXT:
+			fprintf(w, `
+			js.Encode(s.%s());
+		`, title(f.Name()))
+		case TYPE_ENUM, TYPE_STRUCT:
+			fprintf(w, "s.%s().WriteJSON(b);", title(f.Name()))
+		}
+	case FIELD_GROUP:
+		tid := f.Group().TypeId()
+		n := findNode(tid)
+		fprintf(w, "{ s := s.%s();", title(f.Name()))
+		n.jsonStruct(w)
+		fprintf(w, "};")
+	}
+}
+
 func (n *node) defineNewStructFunc(w io.Writer) {
 	assert(n.Which() == NODE_STRUCT, "invalid struct node")
 
@@ -765,12 +838,14 @@ func main() {
 			case NODE_ANNOTATION:
 			case NODE_ENUM:
 				n.defineEnum(&buf)
+				n.defineTypeJsonFunc(&buf)
 			case NODE_STRUCT:
 				if !n.Struct().IsGroup() {
 					n.defineStructTypes(&buf, nil)
 					n.defineStructEnums(&buf)
 					n.defineNewStructFunc(&buf)
 					n.defineStructFuncs(&buf)
+					n.defineTypeJsonFunc(&buf)
 					n.defineStructList(&buf)
 				}
 			}
@@ -785,6 +860,11 @@ func main() {
 
 		fprintf(file, "import (\n")
 		fprintf(file, "C \"%s\"\n", go_capnproto_import)
+		fprintf(file, `
+			"io"
+			"encoding/json"
+			"bufio"
+		`)
 		for imp := range g_imported {
 			fprintf(file, "%s\n", strconv.Quote(imp))
 		}

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -731,22 +731,35 @@ func (f *Field) json(w io.Writer) {
 	switch f.Which() {
 	case FIELD_SLOT:
 		fs := f.Slot()
-		switch fs.Type().Which() {
-		case TYPE_UINT8, TYPE_UINT16, TYPE_UINT32, TYPE_UINT64,
-			TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_INT64,
-			TYPE_FLOAT32, TYPE_FLOAT64, TYPE_BOOL, TYPE_TEXT:
-			fprintf(w, `
-			js.Encode(s.%s());
-		`, title(f.Name()))
-		case TYPE_ENUM, TYPE_STRUCT:
-			fprintf(w, "s.%s().WriteJSON(b);", title(f.Name()))
-		}
+		fprintf(w, "{ s := s.%s(); ", title(f.Name()))
+		fs.Type().json(w)
+		fprintf(w, "}; ")
 	case FIELD_GROUP:
 		tid := f.Group().TypeId()
 		n := findNode(tid)
 		fprintf(w, "{ s := s.%s();", title(f.Name()))
 		n.jsonStruct(w)
 		fprintf(w, "};")
+	}
+}
+
+func (t Type) json(w io.Writer) {
+	switch t.Which() {
+	case TYPE_UINT8, TYPE_UINT16, TYPE_UINT32, TYPE_UINT64,
+		TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_INT64,
+		TYPE_FLOAT32, TYPE_FLOAT64, TYPE_BOOL, TYPE_TEXT, TYPE_DATA:
+		fprintf(w, "js.Encode(s);")
+	case TYPE_ENUM, TYPE_STRUCT:
+		// since we handle groups at the field level, only named struct types make it in here
+		// so we can just call the named structs json dumper
+		fprintf(w, "s.WriteJSON(b);")
+	case TYPE_LIST:
+		fprintf(w, "{ b.WriteByte('[');")
+		fprintf(w, "for i, s := range s.ToArray() {")
+		fprintf(w, `if i != 0 { b.WriteString(", ")};`)
+		typ := t.List().ElementType()
+		typ.json(w)
+		fprintf(w, "}; b.WriteByte(']'); };")
 	}
 }
 

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -679,20 +679,26 @@ func (n *node) defineStructFuncs(w io.Writer) {
 // In that case, Make a new block and redeclare s
 func (n *node) defineTypeJsonFuncs(w io.Writer) {
 	g_imported["io"] = true
-	g_imported["encoding/json"] = true
 	g_imported["bufio"] = true
 	g_imported["bytes"] = true
 
-	fprintf(w, "func (s %s) WriteJSON(w io.Writer) error {\n", n.name)
-	fprintf(w, `
-		b := bufio.NewWriter(w)
-		js := json.NewEncoder(b);`)
+	buf := bytes.Buffer{}
+
 	switch n.Which() {
 	case NODE_ENUM:
-		n.jsonEnum(w)
+		n.jsonEnum(&buf)
 	case NODE_STRUCT:
-		n.jsonStruct(w)
+		n.jsonStruct(&buf)
 	}
+
+	fprintf(w, "func (s %s) WriteJSON(w io.Writer) error {\n", n.name)
+	fprintf(w, "b := bufio.NewWriter(w);")
+	if jsUsed {
+		fprintf(w, "js := json.NewEncoder(b);")
+		g_imported["encoding/json"] = true
+		jsUsed = false
+	}
+	io.Copy(w, &buf)
 
 	fprintf(w, "b.Flush(); return nil\n};\n")
 
@@ -701,8 +707,11 @@ func (n *node) defineTypeJsonFuncs(w io.Writer) {
 }
 
 func (n *node) jsonEnum(w io.Writer) {
+	jsUsed = true
 	fprintf(w, `js.Encode(s.String());`)
 }
+
+var jsUsed bool
 
 // Write statements that will write a json struct
 func (n *node) jsonStruct(w io.Writer) {
@@ -748,6 +757,7 @@ func (t Type) json(w io.Writer) {
 	case TYPE_UINT8, TYPE_UINT16, TYPE_UINT32, TYPE_UINT64,
 		TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_INT64,
 		TYPE_FLOAT32, TYPE_FLOAT64, TYPE_BOOL, TYPE_TEXT, TYPE_DATA:
+		jsUsed = true
 		fprintf(w, "js.Encode(s);")
 	case TYPE_ENUM, TYPE_STRUCT:
 		// since we handle groups at the field level, only named struct types make it in here

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -693,6 +693,7 @@ func (n *node) defineTypeJsonFuncs(w io.Writer) {
 
 	fprintf(w, "func (s %s) WriteJSON(w io.Writer) error {\n", n.name)
 	fprintf(w, "b := bufio.NewWriter(w);")
+	fprintf(w, "var err error;")
 	if jsUsed {
 		fprintf(w, "js := json.NewEncoder(b);")
 		g_imported["encoding/json"] = true
@@ -700,22 +701,28 @@ func (n *node) defineTypeJsonFuncs(w io.Writer) {
 	}
 	io.Copy(w, &buf)
 
-	fprintf(w, "b.Flush(); return nil\n};\n")
+	fprintf(w, "err = b.Flush(); return err\n};\n")
 
 	fprintf(w, "func (s %s) MarshalJSON() ([]byte, error) {\n", n.name)
-	fprintf(w, "b := bytes.Buffer{}; s.WriteJSON(&b); return b.Bytes(), nil };")
+	fprintf(w, "b := bytes.Buffer{}; err := s.WriteJSON(&b); return b.Bytes(), err };")
+}
+
+func writeErrCheck(w io.Writer) {
+	fprintf(w, "if err != nil { return err; };")
 }
 
 func (n *node) jsonEnum(w io.Writer) {
 	jsUsed = true
-	fprintf(w, `js.Encode(s.String());`)
+	fprintf(w, `err = js.Encode(s.String());`)
+	writeErrCheck(w)
 }
 
 var jsUsed bool
 
 // Write statements that will write a json struct
 func (n *node) jsonStruct(w io.Writer) {
-	fprintf(w, `b.WriteByte('{');`)
+	fprintf(w, `err = b.WriteByte('{');`)
+	writeErrCheck(w)
 	for i, f := range n.codeOrderFields() {
 		if f.DiscriminantValue() != 0xFFFF {
 			enumname := fmt.Sprintf("%s_%s", strings.ToUpper(n.name), strings.ToUpper(f.Name()))
@@ -723,16 +730,19 @@ func (n *node) jsonStruct(w io.Writer) {
 		}
 		if i != 0 {
 			fprintf(w, `
-				b.WriteByte(',');
+				err = b.WriteByte(',');
 			`)
+			writeErrCheck(w)
 		}
-		fprintf(w, `b.WriteString("\"%s\":");`, f.Name())
+		fprintf(w, `_, err = b.WriteString("\"%s\":");`, f.Name())
+		writeErrCheck(w)
 		f.json(w)
 		if f.DiscriminantValue() != 0xFFFF {
 			fprintf(w, "};")
 		}
 	}
-	fprintf(w, `b.WriteByte('}');`)
+	fprintf(w, `err = b.WriteByte('}');`)
+	writeErrCheck(w)
 }
 
 // This function writes statements that write the fields json representation to the bufio.
@@ -758,18 +768,23 @@ func (t Type) json(w io.Writer) {
 		TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_INT64,
 		TYPE_FLOAT32, TYPE_FLOAT64, TYPE_BOOL, TYPE_TEXT, TYPE_DATA:
 		jsUsed = true
-		fprintf(w, "js.Encode(s);")
+		fprintf(w, "err = js.Encode(s);")
+		writeErrCheck(w)
 	case TYPE_ENUM, TYPE_STRUCT:
 		// since we handle groups at the field level, only named struct types make it in here
 		// so we can just call the named structs json dumper
 		fprintf(w, "s.WriteJSON(b);")
+		writeErrCheck(w)
 	case TYPE_LIST:
-		fprintf(w, "{ b.WriteByte('[');")
+		fprintf(w, "{ err = b.WriteByte('[');")
+		writeErrCheck(w)
 		fprintf(w, "for i, s := range s.ToArray() {")
-		fprintf(w, `if i != 0 { b.WriteString(", ")};`)
+		fprintf(w, `if i != 0 { _, err = b.WriteString(", "); };`)
+		writeErrCheck(w)
 		typ := t.List().ElementType()
 		typ.json(w)
-		fprintf(w, "}; b.WriteByte(']'); };")
+		fprintf(w, "}; err = b.WriteByte(']'); };")
+		writeErrCheck(w)
 	}
 }
 

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -678,6 +678,11 @@ func (n *node) defineStructFuncs(w io.Writer) {
 // The value will be in scope as s. Some features need to redefine s, like unions.
 // In that case, Make a new block and redeclare s
 func (n *node) defineTypeJsonFuncs(w io.Writer) {
+	g_imported["io"] = true
+	g_imported["encoding/json"] = true
+	g_imported["bufio"] = true
+	g_imported["bytes"] = true
+
 	fprintf(w, "func (s %s) WriteJSON(w io.Writer) error {\n", n.name)
 	fprintf(w, `
 		b := bufio.NewWriter(w)
@@ -863,12 +868,6 @@ func main() {
 
 		fprintf(file, "import (\n")
 		fprintf(file, "C \"%s\"\n", go_capnproto_import)
-		fprintf(file, `
-			"io"
-			"encoding/json"
-			"bufio"
-			"bytes"
-		`)
 		for imp := range g_imported {
 			fprintf(file, "%s\n", strconv.Quote(imp))
 		}

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -677,7 +677,7 @@ func (n *node) defineStructFuncs(w io.Writer) {
 // For all statements, the json encoder js and the bufio writer b will be in scope.
 // The value will be in scope as s. Some features need to redefine s, like unions.
 // In that case, Make a new block and redeclare s
-func (n *node) defineTypeJsonFunc(w io.Writer) {
+func (n *node) defineTypeJsonFuncs(w io.Writer) {
 	fprintf(w, "func (s %s) WriteJSON(w io.Writer) error {\n", n.name)
 	fprintf(w, `
 		b := bufio.NewWriter(w)
@@ -689,7 +689,10 @@ func (n *node) defineTypeJsonFunc(w io.Writer) {
 		n.jsonStruct(w)
 	}
 
-	fprintf(w, "b.Flush(); return nil\n}\n")
+	fprintf(w, "b.Flush(); return nil\n};\n")
+
+	fprintf(w, "func (s %s) MarshalJSON() ([]byte, error) {\n", n.name)
+	fprintf(w, "b := bytes.Buffer{}; s.WriteJSON(&b); return b.Bytes(), nil };")
 }
 
 func (n *node) jsonEnum(w io.Writer) {
@@ -838,14 +841,14 @@ func main() {
 			case NODE_ANNOTATION:
 			case NODE_ENUM:
 				n.defineEnum(&buf)
-				n.defineTypeJsonFunc(&buf)
+				n.defineTypeJsonFuncs(&buf)
 			case NODE_STRUCT:
 				if !n.Struct().IsGroup() {
 					n.defineStructTypes(&buf, nil)
 					n.defineStructEnums(&buf)
 					n.defineNewStructFunc(&buf)
 					n.defineStructFuncs(&buf)
-					n.defineTypeJsonFunc(&buf)
+					n.defineTypeJsonFuncs(&buf)
 					n.defineStructList(&buf)
 				}
 			}
@@ -864,6 +867,7 @@ func main() {
 			"io"
 			"encoding/json"
 			"bufio"
+			"bytes"
 		`)
 		for imp := range g_imported {
 			fprintf(file, "%s\n", strconv.Quote(imp))


### PR DESCRIPTION
This adds support for writing a JSON representation of capnproto structs and enums.

For most users, the MarshalJSON implementation will be enough but for large structs, there's the WriteJSON method which will stream the JSON data into a writer.
