### PR TITLE
Make go-capnproto 32-bit compatible

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -31,7 +31,7 @@ func NewBuffer(data []byte) *Segment {
 }
 
 func (b *buffer) NewSegment(minsz int) (*Segment, error) {
-	if uint64(len(b.Data)) > uint64(math.MaxUint32-minsz) {
+	if uint64(len(b.Data)) > uint64(math.MaxUint32)-uint64(minsz) {
 		return nil, ErrOverlarge
 	}
 	b.Data = append(b.Data, make([]byte, minsz)...)


### PR DESCRIPTION
math.MaxUint32 is too big for an int context:
"constant 4294967295 overflows int"

With this change the code compiles and runs on 32-bit machines.
